### PR TITLE
Align services with rearchitecture roles

### DIFF
--- a/REARCHITECTURE.md
+++ b/REARCHITECTURE.md
@@ -1,0 +1,90 @@
+# htbase rearchitecture (cloud-agnostic)
+
+This document turns the previous high-level proposal into an implementation-ready plan. It keeps the FastAPI surface and existing provider abstractions but decomposes responsibilities into small services that can run on Docker Compose (VPS), Kubernetes, or Cloud Run without code changes.
+
+## Service architecture
+
+### API Gateway (FastAPI)
+- Exposes `/archives` and `/summaries` endpoints that **enqueue** work instead of executing archivers inline.
+- Emits structured job IDs (UUIDv4) and persists a thin job record (status, timestamps, queue target) to Postgres/Firestore via the Storage API.
+- Accepts callback webhooks from workers to update status and trigger follow-up actions (e.g., enqueue summary).
+- Hosts minimal UI/health endpoints; no archiver binaries baked in.
+
+### Archiver workers (Celery)
+- One image per archiver type (`monolith`, `singlefile-cli`, `readability`, `pdf`, `screenshot`) reusing the `BaseArchiver` contract.
+- Each worker defines a Celery task named `archive.<archiver>` bound to a queue of the same name.
+- Tasks pull the original request payload (URL, options, request metadata) from the broker and:
+  1. Run the archiver binary.
+  2. Upload produced artifacts via the Storage API (`/files` endpoint) with idempotent keys (`{job_id}/{archiver}.{ext}`).
+  3. Notify the API Gateway via callback (`/archives/{job_id}/complete`) with artifact locations and any errors.
+
+### Summarization worker
+- Celery task `summary.generate` on queue `summary` triggered by the API Gateway after an archive completes.
+- Fetches artifacts through the Storage API download endpoint.
+- Generates LLM summaries and writes results back through the Storage API (`/data/summaries`).
+- Implements idempotency by hashing the artifact URLs + model ID; skips work if the hash already exists.
+
+### Storage API
+- FastAPI service that hides provider specifics and performs dual writes.
+- Endpoints:
+  - `POST /files`: accepts `provider_hint` (`gcs|local`) and streams bytes; returns canonical URI + etag.
+  - `GET /files/{uri}`: proxies download to the active file provider.
+  - `POST /data/archives` and `POST /data/summaries`: persist metadata first to Postgres, then asynchronously replicate to Firestore; returns record IDs.
+- Applies ordering rules (Postgres-first, Firestore-best-effort) and emits metrics (`write_latency_ms`, `replica_status`).
+
+### Redis + Celery
+- Default broker/result backend; connection set via `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` env vars.
+- Queue map:
+  - `archive.monolith`, `archive.singlefile`, `archive.readability`, `archive.pdf`, `archive.screenshot`
+  - `summary`
+- Task payload schema (JSON): `{ "job_id": "<uuid>", "archiver": "monolith", "url": "...", "options": {...}, "callback_url": "https://api/archives/{job_id}/complete" }`.
+
+## Deployment profiles
+
+### Docker Compose (VPS/local)
+- Services: `api-gateway`, `storage-api`, `redis`, one container per archiver worker, `summary-worker`.
+- Bind-mount a volume for local file storage when `FILE_STORAGE_PROVIDER=local`.
+- Example snippet:
+  ```yaml
+  services:
+    redis:
+      image: redis:7
+    api-gateway:
+      build: ./app
+      environment:
+        CELERY_BROKER_URL: redis://redis:6379/0
+    storage-api:
+      build: ./storage-api
+    worker-monolith:
+      build: ./workers/monolith
+      environment:
+        CELERY_BROKER_URL: redis://redis:6379/0
+        QUEUE: archive.monolith
+  ```
+
+### Kubernetes / Cloud Run
+- Reuse the same images; configure per-queue Deployments/Services (K8s) or per-queue revisions (Cloud Run).
+- Use a managed Redis if available; otherwise deploy Redis in a small StatefulSet.
+- Externalize secrets via K8s Secrets or Cloud Run env vars; mount Service Account credentials only for storage providers that need them.
+
+## Migration roadmap
+1. **Refactor FastAPI task managers** to publish Celery tasks instead of running archivers inline; store job metadata via Storage API.
+2. **Extract archiver workers** into dedicated packages/images; wire Celery queue names and callback URLs; add health probes.
+3. **Introduce Storage API** and swap direct provider calls in archivers/summarization to HTTP/gRPC client calls.
+4. **Add summarization worker** with idempotent hashing and retries; trigger it from API Gateway callbacks.
+5. **Harden operations**: structured logs with request IDs, metrics export (Prometheus/OpenTelemetry), and dashboards.
+6. **Ship deployment artifacts**: `docker-compose.yml` profile for VPS/local, Helm charts or Terraform for Kubernetes/Cloud Run using the same env contract.
+
+## Configuration reference (env vars)
+- `CELERY_BROKER_URL`, `CELERY_RESULT_BACKEND`
+- `FILE_STORAGE_PROVIDER` (`gcs|local`), `DATA_STORAGE_PROVIDER` (`postgres|firestore`)
+- `POSTGRES_DSN`, `FIRESTORE_PROJECT_ID`, `GCS_BUCKET`, `LOCAL_STORAGE_PATH`
+- `ARCHIVER_QUEUE` (per worker), `SUMMARY_QUEUE` (`summary`), `CALLBACK_BASE_URL`
+- `LOG_LEVEL`, `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `SERVICE_ROLE` (`api-gateway`, `archiver-worker`, `summary-worker`, `all-in-one`) to keep a single image usable across roles
+- `ARCHIVERS` (comma-separated list) to control which archiver queues a process is allowed to serve
+
+## Acceptance criteria
+- All archiving and summarization workloads leave the API Gateway process.
+- Any deployment target (Docker Compose, Kubernetes, Cloud Run) can run the same images with only env-var changes.
+- Dual writes remain coordinated by the Storage API with Postgres as the source of truth and Firestore as best-effort replica.

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from celery import Celery
+
+from core.config import get_settings
+from core.logging import setup_logging
+
+
+_settings = get_settings()
+setup_logging(_settings.log_level)
+
+celery_app = Celery("htbase")
+celery_app.conf.update(
+    broker_url=_settings.celery.broker_url,
+    result_backend=_settings.celery.result_backend,
+    task_always_eager=_settings.celery.task_always_eager,
+    task_default_queue=_settings.celery.default_queue,
+    task_acks_late=True,
+)
+celery_app.autodiscover_tasks(["celery_tasks"])
+
+__all__ = ["celery_app"]

--- a/app/celery_tasks/archive.py
+++ b/app/celery_tasks/archive.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from celery.utils.log import get_task_logger
+
+from celery_app import celery_app
+from celery_worker_runtime import get_worker_runtime
+from task_manager.archiver import BatchItem
+
+logger = get_task_logger(__name__)
+
+
+@celery_app.task(name="htbase.archive.process_item")
+def process_archiver_item(payload: Dict[str, Any]) -> None:
+    """Run a single archiver item inside a Celery worker."""
+    task_id = payload.get("task_id") or "unknown"
+    item_data = payload.get("item") or {}
+    runtime = get_worker_runtime()
+
+    try:
+        batch_item = BatchItem(**item_data)
+    except TypeError as exc:
+        logger.error("Invalid batch payload", extra={"payload": item_data, "error": str(exc)})
+        return
+
+    logger.info(
+        "Celery worker processing archiver item",
+        extra={
+            "task_id": task_id,
+            "archiver": batch_item.archiver_name,
+            "item_id": batch_item.item_id,
+        },
+    )
+
+    runtime.archiver_task_manager._process_item(task_id=task_id, item=batch_item)
+
+    logger.info(
+        "Completed Celery archiver item",
+        extra={
+            "task_id": task_id,
+            "archiver": batch_item.archiver_name,
+            "item_id": batch_item.item_id,
+        },
+    )
+
+
+__all__ = ["process_archiver_item"]

--- a/app/celery_worker_runtime.py
+++ b/app/celery_worker_runtime.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from archivers.factory import ArchiverFactory
+from archivers.monolith import MonolithArchiver
+from archivers.pdf import PDFArchiver
+from archivers.readability import ReadabilityArchiver
+from archivers.screenshot import ScreenshotArchiver
+from archivers.singlefile_cli import SingleFileCLIArchiver
+from core.command_runner import CommandRunner
+from core.config import AppSettings, get_settings
+from core.logging import setup_logging
+from services.summarizer import SummaryService
+from services.providers import ProviderFactory, ProviderChain
+from services.summarization import ArticleChunker, PromptBuilder, ResponseParser
+from storage.database_storage import DatabaseStorageProvider
+from storage.file_storage import FileStorageProvider
+from storage.firestore_storage import FirestoreStorage
+from storage.gcs_file_storage import GCSFileStorage
+from storage.local_file_storage import LocalFileStorage
+from storage.postgres_storage import PostgresStorage
+from task_manager import SummarizationTaskManager, SummarizationCoordinator
+from task_manager.archiver import ArchiverTaskManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkerRuntime:
+    settings: AppSettings
+    archivers: Dict[str, object]
+    file_storage_providers: list[FileStorageProvider]
+    db_storage: DatabaseStorageProvider
+    summarization_manager: Optional[SummarizationTaskManager]
+    summarization: Optional[SummarizationCoordinator]
+    archiver_task_manager: ArchiverTaskManager
+
+
+_worker_runtime: Optional[WorkerRuntime] = None
+
+
+def _build_storage(settings: AppSettings) -> tuple[list[FileStorageProvider], DatabaseStorageProvider]:
+    file_storage_providers: list[FileStorageProvider] = []
+
+    for provider_name in settings.storage_providers:
+        if provider_name == "gcs":
+            try:
+                gcs_storage = GCSFileStorage(
+                    bucket_name=settings.gcs.bucket,
+                    project_id=settings.gcs.project_id,
+                )
+                file_storage_providers.append(gcs_storage)
+                logger.info("Initialized GCS storage for worker", extra={"bucket": settings.gcs.bucket})
+            except Exception as exc:
+                logger.warning("GCS storage unavailable for worker", extra={"error": str(exc)})
+        elif provider_name == "local":
+            backup_dir = settings.local_backup_dir or settings.data_dir
+            local_storage = LocalFileStorage(root_dir=backup_dir)
+            file_storage_providers.append(local_storage)
+            logger.info("Initialized local storage for worker", extra={"path": backup_dir})
+
+    if not file_storage_providers:
+        file_storage_providers.append(LocalFileStorage(root_dir=settings.data_dir))
+        logger.warning("No storage providers configured for worker; defaulting to local")
+
+    primary_db: DatabaseStorageProvider = PostgresStorage()
+    replica_db: Optional[DatabaseStorageProvider] = None
+
+    if settings.enable_dual_persistence and settings.firestore.project_id:
+        try:
+            replica_db = FirestoreStorage(project_id=settings.firestore.project_id)
+            logger.info("Initialized Firestore replica for worker", extra={"project_id": settings.firestore.project_id})
+        except Exception as exc:
+            logger.warning("Firestore unavailable for worker", extra={"error": str(exc)})
+
+    if replica_db:
+        from storage.dual_database_storage import DualDatabaseStorage
+
+        db_storage: DatabaseStorageProvider = DualDatabaseStorage(
+            postgres=primary_db,
+            firestore=replica_db,
+            failure_mode=settings.dual_write_failure_mode,
+        )
+    else:
+        db_storage = primary_db
+
+    return file_storage_providers, db_storage
+
+
+def _build_summarization(settings: AppSettings) -> tuple[Optional[SummaryService], Optional[SummarizationTaskManager], Optional[SummarizationCoordinator]]:
+    if settings.service_role.strip().lower() == "archiver-worker":
+        logger.info("Archiver-only worker role: skipping summarization bootstrap")
+        return None, None, None
+
+    provider_factory = ProviderFactory(settings.summarization)
+    try:
+        providers = provider_factory.create_all_configured()
+    except ValueError as exc:
+        logger.warning("Summarization providers misconfigured", extra={"error": str(exc)})
+        providers = []
+
+    chain = ProviderChain(providers=providers, sticky=settings.summarization.provider_sticky) if providers else None
+
+    chunker = ArticleChunker(chunk_size=settings.summarization.chunk_size)
+    prompt_builder = PromptBuilder()
+    response_parser = ResponseParser()
+
+    summarizer = None
+    if chain and chunker.is_enabled:
+        summarizer = SummaryService(
+            provider=chain,
+            prompt_builder=prompt_builder,
+            response_parser=response_parser,
+            chunker=chunker,
+            settings=settings,
+        )
+
+    queue_manager = SummarizationTaskManager(settings, summarizer=summarizer)
+    coordinator = SummarizationCoordinator(settings, summarizer=summarizer, task_queue=queue_manager.queue)
+    queue_manager.start()
+    return summarizer, queue_manager, coordinator
+
+
+def get_worker_runtime() -> WorkerRuntime:
+    global _worker_runtime
+    if _worker_runtime is not None:
+        return _worker_runtime
+
+    settings = get_settings()
+    setup_logging(settings.log_level)
+
+    file_storage_providers, db_storage = _build_storage(settings)
+
+    command_runner = CommandRunner(debug=settings.log_level == "DEBUG")
+    factory = ArchiverFactory(settings, command_runner, file_storage_providers, db_storage)
+    archiver_classes = {
+        "readability": ReadabilityArchiver,
+        "monolith": MonolithArchiver,
+        "singlefile-cli": SingleFileCLIArchiver,
+        "screenshot": ScreenshotArchiver,
+        "pdf": PDFArchiver,
+    }
+    for archiver_name in settings.archivers:
+        archiver_cls = archiver_classes.get(archiver_name)
+        if archiver_cls is None:
+            logger.warning("Worker skipping unknown archiver", extra={"archiver": archiver_name})
+            continue
+        factory.register(archiver_name, archiver_cls)
+    archivers = factory.create_all()
+
+    summarizer, summary_manager, summarization_coordinator = _build_summarization(settings)
+
+    task_manager = ArchiverTaskManager(
+        settings,
+        archivers,
+        summarization=summarization_coordinator,
+    )
+
+    _worker_runtime = WorkerRuntime(
+        settings=settings,
+        archivers=archivers,
+        file_storage_providers=file_storage_providers,
+        db_storage=db_storage,
+        summarization_manager=summary_manager,
+        summarization=summarization_coordinator,
+        archiver_task_manager=task_manager,
+    )
+    return _worker_runtime

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,7 +2,9 @@ fastapi==0.116.1
 uvicorn[standard]==0.35.0
 pydantic-settings==2.6.1
 pydantic==2.11.9
+celery==5.4.0
 pytest==8.4.2
+pytest-asyncio>=0.24.0
 pytest-mock>=3.12.0
 pytest-benchmark>=4.0.0
 psutil>=5.9.0


### PR DESCRIPTION
## Summary
- add service role and archiver list configuration to support API gateway and worker specializations
- update the FastAPI server to skip local archiver/summarization bootstrapping for API-only role while dispatching via Celery
- align Celery worker runtime with configured archiver set and document the new environment knobs

## Testing
- pytest tests/unit -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b28760b048323bd06ca123198b6ae)